### PR TITLE
Add a Mod Setting that allows players to enable a needy warning beep

### DIFF
--- a/Assets/CreaturesModule/Modules/WhoModule.prefab
+++ b/Assets/CreaturesModule/Modules/WhoModule.prefab
@@ -278,6 +278,7 @@ GameObject:
   - component: {fileID: 11420980}
   - component: {fileID: 9598622}
   - component: {fileID: 11460960}
+  - component: {fileID: 114885782031015840}
   m_Layer: 0
   m_Name: WhoModule
   m_TagString: Untagged
@@ -1235,6 +1236,7 @@ MonoBehaviour:
   - {fileID: 425736}
   timeGain: 20
   timeMax: 80
+  modSet: {fileID: 114885782031015840}
   moveDelta: 0.001
 --- !u!114 &11429812
 MonoBehaviour:
@@ -1518,3 +1520,16 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   ShaderNames:
   - KT/Mobile/DiffuseTint
+--- !u!114 &114885782031015840
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 172616}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -289456416, guid: 45b809be76fd7a3468b6f517bced6f28, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Settings: 0.12 True agifuhasdfiugahsdf fgnx cgb fg
+  SettingsPath: 

--- a/Assets/CreaturesModule/Modules/WhoModule.prefab
+++ b/Assets/CreaturesModule/Modules/WhoModule.prefab
@@ -279,6 +279,7 @@ GameObject:
   - component: {fileID: 9598622}
   - component: {fileID: 11460960}
   - component: {fileID: 114885782031015840}
+  - component: {fileID: 114737412504301846}
   m_Layer: 0
   m_Name: WhoModule
   m_TagString: Untagged
@@ -1223,6 +1224,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   Audio: {fileID: 11460960}
   NeedyModule: {fileID: 11453646}
+  BombInfo: {fileID: 114737412504301846}
   CD: {fileID: 11400000, guid: 555eac9788949fe46a19d08fb4c054ce, type: 2}
   screenSR: {fileID: 21232104}
   buttons:
@@ -1520,6 +1522,17 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   ShaderNames:
   - KT/Mobile/DiffuseTint
+--- !u!114 &114737412504301846
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 172616}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 2144496390, guid: 45b809be76fd7a3468b6f517bced6f28, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114885782031015840
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/Assets/CreaturesModule/Scripts/MonsplodeFightModule.cs
+++ b/Assets/CreaturesModule/Scripts/MonsplodeFightModule.cs
@@ -38,8 +38,10 @@ public class MonsplodeFightModule : MonoBehaviour
 		string[] setWords = modSet.Settings.Split();
 		if (setWords != null)
 		{
-			float ey = float.Parse(setWords[0]);
-			missingNoChance = Mathf.Clamp(ey,0f,1f);
+            float ey;
+            if (float.TryParse(setWords[0], out ey)) {
+			    missingNoChance = Mathf.Clamp(ey,0f,1f);
+			}
 		}
 		Init();
         Module.OnActivate += ActivateModule;

--- a/Assets/CreaturesModule/Scripts/MonsplodeWhoModule.cs
+++ b/Assets/CreaturesModule/Scripts/MonsplodeWhoModule.cs
@@ -7,6 +7,7 @@ public class MonsplodeWhoModule : MonoBehaviour
 {
     public KMAudio Audio;
     public KMNeedyModule NeedyModule;
+    public KMBombInfo BombInfo;
     public CreatureDataObject CD;
     public SpriteRenderer screenSR;
     public KMSelectable[] buttons;
@@ -33,6 +34,12 @@ public class MonsplodeWhoModule : MonoBehaviour
                 alarmEnabled = ae;
             }
         }
+        BombInfo.OnBombExploded += () => {
+            if (audioRef != null) {
+                audioRef.StopSound();
+                audioRef = null;
+            }
+        };
     }
 
     void Awake()
@@ -52,7 +59,8 @@ public class MonsplodeWhoModule : MonoBehaviour
         };
     }
 
-    void Update() {
+    void Update() 
+    {
         if (!alarmEnabled) return;
         if (isActivated && audioRef == null && NeedyModule.GetNeedyTimeRemaining() < 5f) {
             audioRef = Audio.PlayGameSoundAtTransformWithRef(KMSoundOverride.SoundEffect.NeedyWarning, this.transform);

--- a/Assets/CreaturesModule/Scripts/MonsplodeWhoModule.cs
+++ b/Assets/CreaturesModule/Scripts/MonsplodeWhoModule.cs
@@ -12,10 +12,13 @@ public class MonsplodeWhoModule : MonoBehaviour
     public KMSelectable[] buttons;
     public Transform[] DP, UP;
     public int timeGain, timeMax;
+    public KMModSettings modSet;
     int crID;
     public float moveDelta;
     bool leftTrue, isActivated = false, revive = false;
     private string textLeft, textRight;
+    bool alarmEnabled = false;
+    KMAudio.KMAudioRef audioRef = null;
 
     private static int _moduleIdCounter = 1;
     private int _moduleId;
@@ -23,6 +26,13 @@ public class MonsplodeWhoModule : MonoBehaviour
     void Start()
     {
         _moduleId = _moduleIdCounter++;
+        string[] setWords = modSet.Settings.Split(new char[] { ' ', '\n', '\t', '\r' }, System.StringSplitOptions.RemoveEmptyEntries);
+        if (setWords != null && setWords.Length > 1) {
+            bool ae = false;
+            if (bool.TryParse(setWords[1], out ae)) {
+                alarmEnabled = ae;
+            }
+        }
     }
 
     void Awake()
@@ -41,6 +51,17 @@ public class MonsplodeWhoModule : MonoBehaviour
             return false;
         };
     }
+
+    void Update() {
+        if (!alarmEnabled) return;
+        if (isActivated && audioRef == null && NeedyModule.GetNeedyTimeRemaining() < 5f) {
+            audioRef = Audio.PlayGameSoundAtTransformWithRef(KMSoundOverride.SoundEffect.NeedyWarning, this.transform);
+        }
+        else if (audioRef != null && (!isActivated || NeedyModule.GetNeedyTimeRemaining() >= 5f)) {
+            audioRef.StopSound();
+            audioRef = null;
+		}
+	}
 
     protected bool Solve()
     {
@@ -92,6 +113,10 @@ public class MonsplodeWhoModule : MonoBehaviour
     {
         revive = true;
         StartCoroutine(GoDown());
+        if (audioRef != null) {
+            audioRef.StopSound();
+            audioRef = null;
+		}
     }
 
     void PickCreatures()

--- a/Assets/modSettings.json
+++ b/Assets/modSettings.json
@@ -1,2 +1,4 @@
-0.0109
+0.0109 
+False	
 Change the number between 0 and 1 to change special event occurance rate. (1 = 100%, 0 = 0%)
+Change the 'False' to 'True' to enable needy warning beeps for Who's That Monsplode when the timer is low.


### PR DESCRIPTION
This allows users to toggle a setting in the mod settings that enables the low timer needy warning beep.
Default is false. Delete the settings file and restart the game to enable this change in-game if the module is already installed from before.